### PR TITLE
corrected max_model_len to be max_input_length

### DIFF
--- a/generation/get_hf2.py
+++ b/generation/get_hf2.py
@@ -83,7 +83,7 @@ llm = LLM(
     model=model_path,
     tokenizer=model_path,
     dtype="bfloat16",
-    max_model_len=script_args.max_new_tokens,
+    max_model_len=script_args.max_input_length,
     load_format="auto",
     seed=42,
 )


### PR DESCRIPTION
Hi, I ran into an error during generation and I think max_model_len is supposed to be max_input_length instead of max_new_tokens. Could you check on this please?